### PR TITLE
feat: enhance login component

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ Create a new CSS file for the component in the public/css/components directory. 
 
 After you've added the new component, you may need to restart your server to see the changes.
 
+### Login component
+
+The built-in login component now supports additional options that can be configured in the editor:
+
+- **Endpoint** – URL of the backend authentication web service.
+- **Encrypt password** – when enabled, the password is hashed with SHA-256 before being sent.
+- **Google/Microsoft Endpoint** – optional URLs that render extra buttons for federated login with Google or Microsoft.
+
 ## Webserver
 
 The file webserver.js, located in the js folder, serves as the configuration file for the web server. It initializes the web server and converts Swagger documentation into a draggable and droppable API list.

--- a/public/css/components/loginComponent.css
+++ b/public/css/components/loginComponent.css
@@ -27,3 +27,13 @@
     background: #fff;
     cursor: pointer;
 }
+
+.login-btn.google {
+    background: #db4437;
+    color: #fff;
+}
+
+.login-btn.microsoft {
+    background: #2f2f2f;
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- add editor options for endpoint, password hashing and Google/Microsoft OAuth URLs
- hash password before submit and show social login buttons
- document new login component options

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c346cdef4c8321906a56096a292c63