### PR TITLE
Add database-backed authentication endpoint

### DIFF
--- a/OdbcDatabase.js
+++ b/OdbcDatabase.js
@@ -101,14 +101,14 @@ class OdbcDatabase {
     }
   }
 
-  async queryData(queryString) {
+  async queryData(queryString, params = []) {
     try {
       console.log(queryString);
       // Execute the query
 
       const connection = await odbc.connect(this.connectionString);
       await connection.setIsolationLevel(odbc.SQL_TXN_READ_UNCOMMITTED);
-      const result = await connection.query(queryString);
+      const result = await connection.query(queryString, params);
       await connection.close();
       return result;
     } catch (err) {

--- a/authDatabase.js
+++ b/authDatabase.js
@@ -1,0 +1,69 @@
+/*!
+ * Copyright (c) 2023 Mediasoft & Cie S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const LocalStrategy = require('passport-local').Strategy;
+
+module.exports = function (app, session, passport, dbs) {
+
+  const dbAuthConfig = app?.config?.authentication?.database;
+  if (!dbAuthConfig) {
+    console.warn('⚠️  Database authentication is not configured. Skipping /api/db-login endpoint.');
+    return;
+  }
+
+  if (!dbs || typeof dbs.authenticateUser !== 'function') {
+    console.error('❌ dblayer instance is required for database authentication.');
+    return;
+  }
+
+  const strategyName = 'database';
+
+  const authUser = async (username, password, done) => {
+    try {
+      const authenticated = await dbs.authenticateUser(username, password);
+      if (!authenticated) {
+        return done(null, false, { message: 'Incorrect username or password' });
+      }
+
+      const user = {
+        oid: authenticated.username,
+        username: authenticated.username,
+        details: authenticated.record
+      };
+
+      return done(null, user);
+    } catch (error) {
+      console.error('Error during database authentication:', error);
+      return done(error);
+    }
+  };
+
+  passport.use(strategyName, new LocalStrategy(authUser));
+
+  app.post('/api/db-login', (req, res, next) => {
+    passport.authenticate(strategyName, (err, user, info) => {
+      if (err) { return next(err); }
+      if (!user) {
+        return res.status(401).send({ authenticated: false, message: info && info.message });
+      }
+      req.logIn(user, err => {
+        if (err) { return next(err); }
+        res.send({ authenticated: true, username: user.username });
+      });
+    })(req, res, next);
+  });
+
+};

--- a/server.js
+++ b/server.js
@@ -113,6 +113,7 @@ require('./authStatic')(app, session, passport);
 const dblayer = require('./dblayer');
 const dbs = new dblayer(app, session, passport);
 dbs.init();
+require('./authDatabase')(app, session, passport, dbs);
 try {
   dbs.generateRoutes(app, dbs);
 }


### PR DESCRIPTION
## Summary
- add a dedicated Passport strategy and `/api/db-login` endpoint for database authentication
- extend the dblayer to expose a reusable `authenticateUser` helper that works with MySQL and ODBC drivers
- allow parameterized queries in the ODBC adapter and wire the new authentication module into the server bootstrap

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbb79cc48c83218603ab705b1e53fe