### PR TITLE
Allow search window inputs to remain editable

### DIFF
--- a/public/js/components/dataSetComponent.js
+++ b/public/js/components/dataSetComponent.js
@@ -550,10 +550,11 @@ function createFieldFromJson(fieldJson) {
     einput.setAttribute("tagname", fieldJson.fieldType);
     einput.setAttribute("validation", fieldJson.validation);
 
-    // set einput disabled and readonly
+    // set einput disabled and readonly except for search windows, which must remain interactive
     console.log("dataSetComponent einput readonly");
-    einput.disabled = true;
-    einput.readOnly = true;
+    const shouldLockInput = fieldJson.fieldType !== "search_win";
+    einput.disabled = shouldLockInput;
+    einput.readOnly = shouldLockInput;
     if (fieldJson.fieldMandatory) {
       einput.required = true;
     }

--- a/public/js/components/searchWindow.js
+++ b/public/js/components/searchWindow.js
@@ -113,16 +113,17 @@ function createQueryResultModal() {
     if (!inputElement) {
       return;
     }
-    // if the input is disabled, ou readonly, show toast maeessage and return
-    if (inputElement.disabled || inputElement.readOnly) {
+    // Allow updates for search window fields even if they are normally readonly/disabled
+    const isSearchWindowField =
+      inputElement.getAttribute("dataset-field-type") === "search_win";
+    if (!isSearchWindowField && (inputElement.disabled || inputElement.readOnly)) {
       showToast("Input is disabled or readonly");
       return;
-    } else {
-      // set the value of the input element
+    }
 
-      inputElement.value = selectedRowValue;
-      console.log("Input Element Value Set:", inputElement.value);
-    };
+    // set the value of the input element
+    inputElement.value = selectedRowValue;
+    console.log("Input Element Value Set:", inputElement.value);
 
   }; // modalOkBtn.onclick
 


### PR DESCRIPTION
## Summary
- avoid disabling search window inputs when building dataset fields so they remain interactive
- allow the search window modal to populate search_win fields even if other inputs are readonly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6655b17b88321b4469054fd25ae3d