### PR TITLE
Refactor Groq proxy route into dedicated module

### DIFF
--- a/appconfig.js
+++ b/appconfig.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const configPath = path.join(__dirname, 'appconfig.json');
+let baseConfig = {};
+
+try {
+  const fileContent = fs.readFileSync(configPath, 'utf8');
+  baseConfig = JSON.parse(fileContent);
+} catch (err) {
+  console.error('Error loading config file:', err);
+}
+
+const askGroqConfig = {
+  ...baseConfig.askGroq,
+  postUrl:
+    process.env.GROQ_POST_URL ||
+    (baseConfig.askGroq && baseConfig.askGroq.postUrl) ||
+    'https://api.groq.com/openai/v1/chat/completions',
+};
+
+module.exports = {
+  ...baseConfig,
+  askGroq: askGroqConfig,
+};

--- a/askGroqService.js
+++ b/askGroqService.js
@@ -1,0 +1,37 @@
+module.exports = function registerAskGroqRoute(app, askGroqConfig = {}) {
+  const { postUrl } = askGroqConfig;
+
+  if (!postUrl) {
+    console.warn('⚠️  askGroq.postUrl is not configured. The /api/ask-groq route will not be registered.');
+    return;
+  }
+
+  app.post('/api/ask-groq', async (req, res) => {
+    try {
+      const response = await fetch(postUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'llama-3.3-70b-versatile',
+          messages: req.body.messages,
+        }),
+      });
+
+      if (!response.ok) {
+        console.error('❌ AI API fetch failed with status:', response.status);
+        return res.status(response.status).json({
+          error: `AI API error: ${response.statusText}`,
+        });
+      }
+
+      const result = await response.json();
+      res.json(result);
+    } catch (err) {
+      console.error('❌ AI API fetch failed:', err.message);
+      res.status(500).json({ error: 'Failed to fetch from AI API.' });
+    }
+  });
+};


### PR DESCRIPTION
## Summary
- centralize configuration loading in a new appconfig.js helper that exposes the askGroq endpoint
- move the /api/ask-groq proxy into askGroqService.js and register it from server.js using the configured URL

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf2cb44988321808d64f8c3f8f519