### PR TITLE
Load Groq API key from app config

### DIFF
--- a/appconfig.js
+++ b/appconfig.js
@@ -17,6 +17,10 @@ const askGroqConfig = {
     process.env.GROQ_POST_URL ||
     (baseConfig.askGroq && baseConfig.askGroq.postUrl) ||
     'https://api.groq.com/openai/v1/chat/completions',
+  apiKey:
+    process.env.GROQ_API_KEY ||
+    (baseConfig.askGroq && baseConfig.askGroq.apiKey) ||
+    '',
 };
 
 module.exports = {

--- a/askGroqService.js
+++ b/askGroqService.js
@@ -1,8 +1,13 @@
 module.exports = function registerAskGroqRoute(app, askGroqConfig = {}) {
-  const { postUrl } = askGroqConfig;
+  const { postUrl, apiKey } = askGroqConfig;
 
   if (!postUrl) {
     console.warn('⚠️  askGroq.postUrl is not configured. The /api/ask-groq route will not be registered.');
+    return;
+  }
+
+  if (!apiKey) {
+    console.warn('⚠️  askGroq.apiKey is not configured. The /api/ask-groq route will not be registered.');
     return;
   }
 
@@ -11,7 +16,7 @@ module.exports = function registerAskGroqRoute(app, askGroqConfig = {}) {
       const response = await fetch(postUrl, {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+          Authorization: `Bearer ${apiKey}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
- surface the Groq API key in the generated askGroq configuration so it can be provided via env or JSON config
- update the askGroq service to consume the API key from configuration and warn when missing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daf5b7dc7c8321845e07f3de031126