### PR TITLE
Move Groq configuration into appconfig

### DIFF
--- a/appconfig.js
+++ b/appconfig.js
@@ -14,11 +14,9 @@ try {
 const askGroqConfig = {
   ...baseConfig.askGroq,
   postUrl:
-    process.env.GROQ_POST_URL ||
     (baseConfig.askGroq && baseConfig.askGroq.postUrl) ||
     'https://api.groq.com/openai/v1/chat/completions',
   apiKey:
-    process.env.GROQ_API_KEY ||
     (baseConfig.askGroq && baseConfig.askGroq.apiKey) ||
     '',
 };

--- a/appconfig.json
+++ b/appconfig.json
@@ -54,5 +54,9 @@
       "usernameColumn": "username",
       "passwordColumn": "password"
     }
+  },
+  "askGroq": {
+    "postUrl": "https://api.groq.com/openai/v1/chat/completions",
+    "apiKey": ""
   }
 }


### PR DESCRIPTION
## Summary
- add the askGroq endpoint and API key configuration to appconfig.json
- stop reading GROQ settings from environment variables in appconfig.js so they come from appconfig.json

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daf8e8b70c8321b505eb1014c7b5be