### PR TITLE
Configure Groq model via app config

### DIFF
--- a/appconfig.js
+++ b/appconfig.js
@@ -19,6 +19,9 @@ const askGroqConfig = {
   apiKey:
     (baseConfig.askGroq && baseConfig.askGroq.apiKey) ||
     '',
+  model:
+    (baseConfig.askGroq && baseConfig.askGroq.model) ||
+    'llama-3.3-70b-versatile',
 };
 
 module.exports = {

--- a/appconfig.json
+++ b/appconfig.json
@@ -57,6 +57,7 @@
   },
   "askGroq": {
     "postUrl": "https://api.groq.com/openai/v1/chat/completions",
-    "apiKey": ""
+    "apiKey": "",
+    "model": "llama-3.3-70b-versatile"
   }
 }

--- a/askGroqService.js
+++ b/askGroqService.js
@@ -1,5 +1,5 @@
 module.exports = function registerAskGroqRoute(app, askGroqConfig = {}) {
-  const { postUrl, apiKey } = askGroqConfig;
+  const { postUrl, apiKey, model = 'llama-3.3-70b-versatile' } = askGroqConfig;
 
   if (!postUrl) {
     console.warn('⚠️  askGroq.postUrl is not configured. The /api/ask-ai route will not be registered.');
@@ -20,7 +20,7 @@ module.exports = function registerAskGroqRoute(app, askGroqConfig = {}) {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          model: 'llama-3.3-70b-versatile',
+          model,
           messages: req.body.messages,
         }),
       });


### PR DESCRIPTION
## Summary
- move the Groq model identifier into the shared application configuration
- default the askGroq service to use the configured model when sending requests

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dafc35a1848321b1f2b74645128bae