### PR TITLE
Refactor LM API route handling

### DIFF
--- a/askAiService.js
+++ b/askAiService.js
@@ -1,42 +1,74 @@
+const axios = require('axios');
+
 module.exports = function registerAskAiRoute(app, askAIConfig = {}) {
   const { postUrl, apiKey, model = 'llama-3.3-70b-versatile' } = askAIConfig;
 
   if (!postUrl) {
     console.warn('⚠️  askAI.postUrl is not configured. The /api/ask-ai route will not be registered.');
-    return;
   }
 
   if (!apiKey) {
     console.warn('⚠️  askAI.apiKey is not configured. The /api/ask-ai route will not be registered.');
-    return;
   }
 
-  app.post('/api/ask-ai', async (req, res) => {
-    try {
-      const response = await fetch(postUrl, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          model,
-          messages: req.body.messages,
-        }),
-      });
-
-      if (!response.ok) {
-        console.error('❌ AI API fetch failed with status:', response.status);
-        return res.status(response.status).json({
-          error: `AI API error: ${response.statusText}`,
+  if (postUrl && apiKey) {
+    app.post('/api/ask-ai', async (req, res) => {
+      try {
+        const response = await fetch(postUrl, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model,
+            messages: req.body.messages,
+          }),
         });
-      }
 
-      const result = await response.json();
-      res.json(result);
+        if (!response.ok) {
+          console.error('❌ AI API fetch failed with status:', response.status);
+          return res.status(response.status).json({
+            error: `AI API error: ${response.statusText}`,
+          });
+        }
+
+        const result = await response.json();
+        res.json(result);
+      } catch (err) {
+        console.error('❌ AI API fetch failed:', err.message);
+        res.status(500).json({ error: 'Failed to fetch from AI API.' });
+      }
+    });
+  }
+
+  app.post('/api/lm', async (req, res) => {
+    const { prompt } = req.body;
+
+    try {
+      const response = await axios.post(
+        'http://localhost:1234/v1/chat/completions',
+        {
+          model: 'google/gemma-3-12b',
+          messages: [{ role: 'user', content: prompt }],
+          temperature: 0.1,
+          top_p: 0.9,
+          max_tokens: 512,
+          stop: ['}'],
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer lm-studio',
+          },
+          timeout: 15 * 60 * 1000,
+        }
+      );
+
+      res.json(response.data);
     } catch (err) {
-      console.error('❌ AI API fetch failed:', err.message);
-      res.status(500).json({ error: 'Failed to fetch from AI API.' });
+      console.error('❌ LM Studio fetch failed:', err.message);
+      res.status(500).json({ error: 'LM Studio timed out or failed.' });
     }
   });
 };

--- a/server.js
+++ b/server.js
@@ -220,34 +220,6 @@ process.on('rejectionHandled', (promise) => {
   console.warn('🔁 Rejection Handled:', promise);
 });
 
-const axios = require("axios");
-
-app.post("/api/lm", async (req, res) => {
-  const { prompt } = req.body;
-
-  try {
-    const response = await axios.post("http://localhost:1234/v1/chat/completions", {
-      model: "google/gemma-3-12b",  // or whichever model you're using
-      messages: [{ role: "user", content: prompt }],
-      temperature: 0.1,      // low creativity
-      top_p: 0.9,
-      max_tokens: 512,       // or more if your responses are longer
-      stop: ["}"],            // optional, helps terminate JSON
-    }, {
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": "Bearer lm-studio"
-      },
-      timeout: 15 * 60 * 1000  // ✅ 15 minutes
-    });
-
-    res.json(response.data);
-  } catch (err) {
-    console.error("❌ LM Studio fetch failed:", err.message);
-    res.status(500).json({ error: "LM Studio timed out or failed." });
-  }
-});
-
 try {
   app.listen(port, () => {
     console.log(`Server running on port ${port}`);


### PR DESCRIPTION
## Summary
- move the `/api/lm` endpoint registration from `server.js` into `askAiService.js`
- ensure the ask-ai route is only registered when configuration values are provided

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dafefee008832196b9e797e21f8657