### PR TITLE
feat: replace AI form prompt with modal workflow

### DIFF
--- a/public/css/editForm.css
+++ b/public/css/editForm.css
@@ -195,6 +195,119 @@
     margin: 10px;
 }
 
+.ai-form-modal__backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 9998;
+}
+
+.ai-form-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    z-index: 10050;
+}
+
+.ai-form-modal__dialog {
+    width: 100%;
+    max-width: 640px;
+    background-color: var(--color-147);
+    border-radius: 8px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+    border: 1px solid var(--color-9);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 20px;
+}
+
+.ai-form-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.ai-form-modal__header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+}
+
+.ai-form-modal__close {
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font-size: 1.1rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ai-form-modal__body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.ai-form-modal__label {
+    font-weight: 600;
+}
+
+.ai-form-modal__textarea {
+    width: 100%;
+    resize: vertical;
+    min-height: 140px;
+    border-radius: 6px;
+    border: 1px solid var(--color-9);
+    padding: 10px;
+    font-family: inherit;
+    font-size: 0.95rem;
+    background-color: var(--color-147);
+    color: inherit;
+}
+
+.ai-form-modal__textarea:focus {
+    outline: 2px solid var(--color-58);
+    outline-offset: 2px;
+}
+
+.ai-form-modal__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.ai-form-modal__button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+}
+
+.ai-form-modal__status {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--color-2);
+}
+
+.ai-form-modal__status--error {
+    color: #dc3545;
+}
+
+.ai-form-modal__status--success {
+    color: #198754;
+}
+
+.ai-form-modal__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
 
 
 

--- a/views/tabs/editForm.ejs
+++ b/views/tabs/editForm.ejs
@@ -121,6 +121,47 @@
         </button>
     </div>
 
+    <div id="aiFormModalBackdrop" class="ai-form-modal__backdrop is-hidden" aria-hidden="true"></div>
+    <div id="aiFormModal" class="ai-form-modal is-hidden" role="dialog" aria-modal="true" aria-hidden="true"
+        aria-labelledby="aiFormModalTitle">
+        <div class="ai-form-modal__dialog">
+            <div class="ai-form-modal__header">
+                <h2 id="aiFormModalTitle">Create a Form with AI</h2>
+                <button type="button" class="ai-form-modal__close" id="aiFormCancelBtn" aria-label="Close">
+                    <i class="bi bi-x-lg"></i>
+                </button>
+            </div>
+            <div class="ai-form-modal__body">
+                <label for="aiFormRequestInput" class="ai-form-modal__label">Describe the form you want to create</label>
+                <textarea id="aiFormRequestInput" class="ai-form-modal__textarea" rows="6"
+                    placeholder="Explain the structure, fields or behavior you expect..."></textarea>
+
+                <div class="ai-form-modal__actions">
+                    <input type="file" id="aiFormDocumentInput" accept=".txt,.json,.csv,.md,.html,.xml,.yaml,.yml,.pdf"
+                        class="is-hidden">
+                    <button type="button" class="button ai-form-modal__button" id="aiFormLoadDocumentBtn">
+                        <i class="bi bi-upload"></i> Load document
+                    </button>
+                    <button type="button" class="button ai-form-modal__button" id="aiFormAnalyzeBtn">
+                        <i class="bi bi-search"></i> Analyse
+                    </button>
+                    <button type="button" class="button ai-form-modal__button" id="aiFormShowDatabaseBtn">
+                        <i class="bi bi-database"></i> Show database
+                    </button>
+                </div>
+                <p id="aiFormDocumentStatus" class="ai-form-modal__status">No document loaded.</p>
+            </div>
+            <div class="ai-form-modal__footer">
+                <button type="button" class="button ai-form-modal__button" id="aiFormCancelBtnFooter">
+                    Cancel
+                </button>
+                <button type="button" class="button success ai-form-modal__button" id="aiFormGenerateBtn">
+                    Generate form
+                </button>
+            </div>
+        </div>
+    </div>
+
     <script src="editForm.js"></script>
     <link rel="stylesheet" href="/css/editForm.css">
 </div>


### PR DESCRIPTION
## Summary
- replace the browser prompt in the AI form generator with a modal that accepts user descriptions, optional document uploads, and quick access to the database tab
- add the modal markup and styling so the new workflow is accessible and consistent with the editor UI
- harden the AI request flow by validating responses, merging document context, and surfacing clearer error messages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc37eb2e208321a62f448f0c88837d