### PR TITLE
Ensure Prisma CLI is available during production installs

### DIFF
--- a/PrismaDatabase.js
+++ b/PrismaDatabase.js
@@ -105,8 +105,12 @@ class PrismaDatabase {
       if (error?.code === 'P1003') {
         hints.push('Confirm that the specified database exists and that the credentials have access to it.');
       }
-      if (error?.code === 'P5019' || /Query engine library for current platform/i.test(error?.message || '')) {
-        hints.push('Run `npx prisma generate` to rebuild the Prisma client for this platform.');
+      if (
+        error?.code === 'P5019' ||
+        /Query engine library for current platform/i.test(error?.message || '') ||
+        /did not initialize yet/i.test(error?.message || '')
+      ) {
+        hints.push('Install the `prisma` CLI dependency and run `npx prisma generate` to rebuild the Prisma client for this platform.');
       }
       const maskedConnection = maskConnectionString(this.connectionString);
       const messageParts = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@azure/msal-node": "^2.6.0",
+        "@prisma/client": "^5.20.0",
         "@lmstudio/sdk": "^1.3.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "axios": "^1.10.0",
@@ -37,6 +38,7 @@
         "odbc": "^2.4.8",
         "passport": "^0.6.0",
         "passport-local": "^1.0.0",
+        "prisma": "^5.20.0",
         "pug": "^3.0.2",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "odbc": "^2.4.8",
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",
+    "prisma": "^5.20.0",
     "pug": "^3.0.2",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.0"
   },
   "devDependencies": {
-    "@microsoft/microsoft-graph-types": "^2.40.0",
-    "prisma": "^5.20.0"
+    "@microsoft/microsoft-graph-types": "^2.40.0"
   }
 }


### PR DESCRIPTION
## Summary
- include the Prisma CLI in production dependencies so installs using NODE_ENV=production can still build the client
- expand the Prisma error handling to recommend installing the CLI and running `npx prisma generate` when the generated client is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de5f8ebf7c8321870c8f2aca598697