### PR TITLE
Add AI prompt integration for database modal apply

### DIFF
--- a/public/js/dom.js
+++ b/public/js/dom.js
@@ -367,7 +367,7 @@ function initializeAiFormModal() {
 
   showDatabaseBtn?.addEventListener("click", () => {
     if (typeof showModalDbStrc === "function") {
-      showModalDbStrc(null, "dataSetComponent");
+      showModalDbStrc(null, "aiForm");
       closeAiFormModal();
     } else {
       showStatusMessage("Database viewer is not available.", "error");


### PR DESCRIPTION
## Summary
- track the context when opening the database structure modal
- build JSON structures from selected fields and append them to the AI form request
- keep the existing dataset apply behavior while closing the modal safely

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de8b1247308321aa95c871f39c1f06