### PR TITLE
Keep AI form modal open when viewing database structure

### DIFF
--- a/public/css/components/searchWindow.css
+++ b/public/css/components/searchWindow.css
@@ -12,6 +12,14 @@
   background-color: var(--color-119);
 }
 
+.modal--over-ai-form {
+  z-index: 10060;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
 .modal-content {
   background-color: var(--color-2);
 
@@ -19,6 +27,12 @@
   border: 1px solid var(--color-50);
 
   border-radius: 10px;
+}
+
+.modal--over-ai-form .modal-content {
+  width: min(80vw, 1200px);
+  max-height: 90vh;
+  overflow: auto;
 }
 
 .modal-header {

--- a/public/js/db.js
+++ b/public/js/db.js
@@ -781,10 +781,12 @@ function showModalDbStrc(main, type) {
         return;
     }
 
-    modal.dataset.contextType = type || '';
-
     const overl = document.getElementById('overlayModal');
-    modal.style.display = 'block';
+    const isAiFormContext = type === 'aiForm';
+
+    modal.dataset.contextType = type || '';
+    modal.classList.toggle('modal--over-ai-form', isAiFormContext);
+    modal.style.display = isAiFormContext ? 'flex' : 'block';
     // overl.style.display = 'block';
     // get the table list
     const list = modal.querySelector('#modalTableListPanel');
@@ -1065,6 +1067,7 @@ function applyDBModal(button) {
     }
 
     const overl = document.getElementById('overlayModal');
+    modal.classList.remove('modal--over-ai-form');
     modal.style.display = 'none';
     if (overl) {
         overl.style.display = 'none';
@@ -1081,8 +1084,11 @@ function closeModalDbStrct() {
 function closeDBModalEdit(button) {
     const modal = button.closest('.modal');
     const overl = document.getElementById('overlayModal');
+    modal.classList.remove('modal--over-ai-form');
     modal.style.display = 'none';
-    overl.style.display = 'none';
+    if (overl) {
+        overl.style.display = 'none';
+    }
 
 }
 

--- a/public/js/dom.js
+++ b/public/js/dom.js
@@ -368,7 +368,6 @@ function initializeAiFormModal() {
   showDatabaseBtn?.addEventListener("click", () => {
     if (typeof showModalDbStrc === "function") {
       showModalDbStrc(null, "aiForm");
-      closeAiFormModal();
     } else {
       showStatusMessage("Database viewer is not available.", "error");
     }


### PR DESCRIPTION
## Summary
- keep the "Create a Form with AI" modal open when the database structure viewer is launched
- style the database modal to stack above the AI dialog with an 80% viewport width layout and cleanly reset on close

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec631bdc0832195ec29e779890de1