### PR TITLE
Highlight Show DB action in AI form modal

### DIFF
--- a/public/css/editForm.css
+++ b/public/css/editForm.css
@@ -288,6 +288,19 @@
     white-space: nowrap;
 }
 
+.ai-form-modal__button--primary {
+    background: var(--color-58);
+    color: var(--color-2);
+    font-weight: 600;
+    border: none;
+    order: -1;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+}
+
+.ai-form-modal__button--primary:hover {
+    background: var(--color-59);
+}
+
 .ai-form-modal__status {
     margin: 0;
     font-size: 0.9rem;

--- a/views/tabs/editForm.ejs
+++ b/views/tabs/editForm.ejs
@@ -139,14 +139,14 @@
                 <div class="ai-form-modal__actions">
                     <input type="file" id="aiFormDocumentInput" accept=".txt,.json,.csv,.md,.html,.xml,.yaml,.yml,.pdf"
                         class="is-hidden">
+                    <button type="button" class="button ai-form-modal__button ai-form-modal__button--primary" id="aiFormShowDatabaseBtn">
+                        <i class="bi bi-database"></i> Show DB
+                    </button>
                     <button type="button" class="button ai-form-modal__button" id="aiFormLoadDocumentBtn">
                         <i class="bi bi-upload"></i> Load document
                     </button>
                     <button type="button" class="button ai-form-modal__button" id="aiFormAnalyzeBtn">
                         <i class="bi bi-search"></i> Analyse
-                    </button>
-                    <button type="button" class="button ai-form-modal__button" id="aiFormShowDatabaseBtn">
-                        <i class="bi bi-database"></i> Show DB
                     </button>
                 </div>
                 <p id="aiFormDocumentStatus" class="ai-form-modal__status">No document loaded.</p>


### PR DESCRIPTION
## Summary
- move the Show DB control ahead of other AI modal actions so it is immediately accessible
- introduce a primary button style in the AI modal to visually emphasize the Show DB action

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68decfe8d8e88321966766c4ca4d702e