### PR TITLE
Add panel view toggle to forms and pages lists

### DIFF
--- a/views/tabs/formsList.ejs
+++ b/views/tabs/formsList.ejs
@@ -1,35 +1,58 @@
 <div class="tab-pane fade" id="formsList" style="min-height: 500px">
-    <div id="formsListContainer">
+    <div class="d-flex flex-wrap justify-content-between align-items-end gap-2 mb-3">
+        <div class="d-flex flex-wrap gap-2">
+            <div class="input-group input-group-sm" style="width: 180px;">
+                <span class="input-group-text">ID</span>
+                <input id="searchFormInput" onkeyup="searchFormbyID(event)" placeholder="Search by ID"
+                    class="form-control" type="text">
+            </div>
+            <div class="input-group input-group-sm" style="width: 220px;">
+                <span class="input-group-text">Name</span>
+                <input id="searchNameInput" onkeyup="searchFormbyName(event)" placeholder="Search by Name"
+                    class="form-control" type="text">
+            </div>
+            <div class="input-group input-group-sm" style="width: 220px;">
+                <span class="input-group-text">Slug</span>
+                <input id="searchSlugInput" onkeyup="searchFormbySlug(event)" placeholder="Search by Slug"
+                    class="form-control" type="text">
+            </div>
+        </div>
+        <div class="d-flex flex-wrap gap-2">
+            <button onclick="newForm()" class="btn btn-sm btn-success" title="New Form">
+                <i class="bi bi-plus-lg"></i>
+            </button>
+            <div class="btn-group" role="group" aria-label="Forms view toggle">
+                <button type="button" id="formsGridViewBtn" class="btn btn-sm btn-primary"
+                    onclick="toggleFormsView('grid')">
+                    <i class="bi bi-grid"></i>
+                </button>
+                <button type="button" id="formsPanelViewBtn" class="btn btn-sm btn-outline-secondary"
+                    onclick="toggleFormsView('panel')">
+                    <i class="bi bi-view-stacked"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div id="formsEmptyState" class="alert alert-info d-none">No forms available.</div>
+    <div id="formsGridWrapper">
         <table class="table table-striped table-bordered" id="componentsList">
             <thead>
                 <tr>
-                    <th>ID
-                        <input id="searchFormInput" onkeyup="searchFormbyID(event)" placeholder="Search by ID"
-                            style="width: 100px;  display: inline;" type="text">
-                    </th>
-                    <th>Name
-                        <input id="searchNameInput" onkeyup="searchFormbyName(event)" placeholder="Search by Name"
-                            style="width: 100px;  display: inline;" type="text">
-                    </th>
-                    <th>Slug
-                        <input id="searchSlugInput" onkeyup="searchFormbySlug(event)" placeholder="Search by Slug"
-                            style="width: 100px;  display: inline;" type="text">
-                    </th>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Slug</th>
                     <th>User Created</th>
                     <th>User Modified</th>
                     <th>Date</th>
-                    <th>Actions
-                        <button onclick="newForm()"
-                            style="width: 30px; height: 30px; padding: 0; display: inline; align-items: center;"
-                            title="New Form">
-                            <i class="bi bi-plus-lg" style="font-size: 20px;"></i>
-                        </button>
-                    </th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody id="componentsListBody">
                 <!-- Components will be listed here -->
             </tbody>
         </table>
+    </div>
+    <div id="formsPanelWrapper" class="d-none">
+        <div class="row g-3" id="formsPanelContainer"></div>
     </div>
 </div>

--- a/views/tabs/pageList.ejs
+++ b/views/tabs/pageList.ejs
@@ -1,32 +1,53 @@
 <div class="tab-pane fade in active" id="pageList" style="min-height: 500px">
-    <div id="pageListContainer">
+    <div class="d-flex flex-wrap justify-content-between align-items-end gap-2 mb-3">
+        <div class="d-flex flex-wrap gap-2">
+            <div class="input-group input-group-sm" style="width: 180px;">
+                <span class="input-group-text">ID</span>
+                <input id="searchPageInput" onkeyup="searchPagebyID(event)" placeholder="Search by ID"
+                    class="form-control" type="text">
+            </div>
+            <div class="input-group input-group-sm" style="width: 220px;">
+                <span class="input-group-text">Slug</span>
+                <input id="searchPageSlugInput" onkeyup="searchPagebySlug(event)" placeholder="Search by Slug"
+                    class="form-control" type="text">
+            </div>
+        </div>
+        <div class="d-flex flex-wrap gap-2">
+            <button onclick="newPage()" class="btn btn-sm btn-success" title="New Page">
+                <i class="bi bi-plus-lg"></i>
+            </button>
+            <div class="btn-group" role="group" aria-label="Pages view toggle">
+                <button type="button" id="pagesGridViewBtn" class="btn btn-sm btn-primary"
+                    onclick="togglePagesView('grid')">
+                    <i class="bi bi-grid"></i>
+                </button>
+                <button type="button" id="pagesPanelViewBtn" class="btn btn-sm btn-outline-secondary"
+                    onclick="togglePagesView('panel')">
+                    <i class="bi bi-view-stacked"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div id="pagesEmptyState" class="alert alert-info d-none">No pages available.</div>
+    <div id="pagesGridWrapper">
         <table class="table table-striped table-bordered" id="ListPageContainer">
             <thead>
                 <tr>
-                    <th>ID
-                        <input id="searchPageInput" onkeyup="searchPagebyID(event)" placeholder="Search by ID"
-                            style="width: 100px;  display: inline;" type="text">
-                    </th>
-                    <th>Slug
-                        <input id="searchPageSlugInput" onkeyup="searchPagebySlug(event)" placeholder="Search by Slug"
-                            style="width: 100px;  display: inline;" type="text">
-                    </th>
-                    <th>layout</th>
-                    <th>title</th>
-                    <th>meta.description</th>
-                    <th>meta.keywords</th>
-                    <th>Actions
-                        <button onclick="newPage()"
-                            style="width: 30px; height: 30px; padding: 0; display: inline; align-items: center;"
-                            title="New Page">
-                            <i class="bi bi-plus-lg" style="font-size: 20px;"></i>
-                        </button>
-                    </th>
+                    <th>ID</th>
+                    <th>Slug</th>
+                    <th>Layout</th>
+                    <th>Title</th>
+                    <th>Meta Description</th>
+                    <th>Meta Keywords</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody id="pageListContainerBody">
                 <!-- Components will be listed here -->
             </tbody>
         </table>
+    </div>
+    <div id="pagesPanelWrapper" class="d-none">
+        <div class="row g-3" id="pagesPanelContainer"></div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add shared toolbar controls with search fields and view toggles to the forms and pages tabs
- render grid and card panel layouts for both lists while reusing action buttons and empty states
- refactor form and page list scripts to filter data, manage view state, and keep the UI in sync after edits or deletions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dee93502ec8321ada4b18b848d5a26