### PR TITLE
Enhance PDF document component with HTML component palette

### DIFF
--- a/public/css/components/pdfDocumentComponent.css
+++ b/public/css/components/pdfDocumentComponent.css
@@ -150,6 +150,51 @@
   cursor: grabbing;
 }
 
+.pdf-component-palette {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid #e4e7ec;
+  border-radius: 6px;
+  background-color: #ffffff;
+}
+
+.pdf-component-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+  padding: 10px 12px;
+  background: linear-gradient(180deg, #f9fafb 0%, #f1f5f9 100%);
+  border: 1px solid #d0d5dd;
+  border-radius: 6px;
+  cursor: grab;
+  text-align: left;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.pdf-component-chip:hover {
+  border-color: #6366f1;
+  box-shadow: 0 2px 6px rgba(99, 102, 241, 0.2);
+  transform: translateY(-1px);
+}
+
+.pdf-component-chip:active {
+  cursor: grabbing;
+}
+
+.pdf-component-chip-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #1d2939;
+}
+
+.pdf-component-chip-description {
+  font-size: 0.78rem;
+  color: #667085;
+}
+
 .pdf-field-empty {
   color: #98a2b3;
   font-style: italic;
@@ -290,6 +335,90 @@
 .pdf-editor-actions button:hover {
   transform: translateY(-1px);
   box-shadow: 0 2px 6px rgba(37, 99, 235, 0.35);
+}
+
+.pdf-heading {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: #1d2939;
+  margin: 0 0 12px;
+}
+
+.pdf-subheading {
+  font-size: 1.3rem;
+  font-weight: 500;
+  color: #344054;
+  margin: 16px 0 10px;
+}
+
+.pdf-paragraph {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #475467;
+  margin: 0 0 16px;
+}
+
+.pdf-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+  gap: 12px;
+  margin: 16px 0;
+}
+
+.pdf-column {
+  border: 1px solid #e4e7ec;
+  border-radius: 6px;
+  padding: 12px;
+  background-color: #f8fafc;
+  color: #475467;
+  font-size: 0.95rem;
+  min-height: 60px;
+}
+
+.pdf-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+  font-size: 0.9rem;
+}
+
+.pdf-table thead {
+  background-color: #f8fafc;
+  color: #1d2939;
+}
+
+.pdf-table th,
+.pdf-table td {
+  border: 1px solid #d0d5dd;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.pdf-separator {
+  border: none;
+  border-top: 1px solid #d0d5dd;
+  margin: 20px 0;
+}
+
+.pdf-signature {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 24px 0 12px;
+  color: #344054;
+}
+
+.pdf-signature-line {
+  width: 240px;
+  border-bottom: 1px solid #1d2939;
+  height: 28px;
+}
+
+.pdf-signature-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475467;
 }
 
 .pdf-document-export {


### PR DESCRIPTION
## Summary
- add a reusable component palette with draggable HTML snippets for the PDF document editor
- allow inserting predefined layout elements into templates and update live preview handling
- style the new component picker and predefined HTML structures for improved PDF output

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e022d1d09c8321aa960d416d01970b