### PR TITLE
Move PDF editor configuration into modal

### DIFF
--- a/public/css/components/pdfDocumentComponent.css
+++ b/public/css/components/pdfDocumentComponent.css
@@ -454,27 +454,6 @@
   overflow-y: auto;
 }
 
-.pdf-dataset-modal__template {
-  margin: 0;
-  border: 1px dashed #cbd2e0;
-  border-radius: 6px;
-  min-height: 160px;
-  padding: 12px;
-  background-color: #ffffff;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
-  font-size: 0.85rem;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: #1d2939;
-}
-
-.pdf-dataset-modal__template--empty {
-  color: #98a2b3;
-  font-style: italic;
-}
-
 .pdf-template-editor.drag-over {
   border-color: #6366f1;
   box-shadow: inset 0 0 0 2px rgba(99, 102, 241, 0.15);


### PR DESCRIPTION
## Summary
- move the field palette, component palette, and template editor into the dataset modal instead of the property pane
- refresh modal helper text/button labels and remove unused template preview styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14b463da48321af64b4079a4bcdb8