### PR TITLE
Add HTML source editor to PDF document modal

### DIFF
--- a/public/css/components/pdfDocumentComponent.css
+++ b/public/css/components/pdfDocumentComponent.css
@@ -454,6 +454,38 @@
   overflow-y: auto;
 }
 
+.pdf-template-html-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 16px;
+}
+
+.pdf-template-html-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #475467;
+}
+
+.pdf-template-html-textarea {
+  min-height: 200px;
+  border: 1px solid #d0d5dd;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85rem;
+  color: #1d2939;
+  background-color: #f8fafc;
+  resize: vertical;
+  line-height: 1.45;
+}
+
+.pdf-template-html-textarea:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.45);
+}
+
 .pdf-template-editor.drag-over {
   border-color: #6366f1;
   box-shadow: inset 0 0 0 2px rgba(99, 102, 241, 0.15);

--- a/public/js/components/pdfDocumentComponent.js
+++ b/public/js/components/pdfDocumentComponent.js
@@ -91,6 +91,28 @@ function ensurePdfDatasetStructureModal() {
   modalTemplateEditor.setAttribute("aria-live", "polite");
   modalTemplateSection.appendChild(modalTemplateEditor);
 
+  const modalTemplateHtmlWrapper = document.createElement("div");
+  modalTemplateHtmlWrapper.className = "pdf-template-html-wrapper";
+
+  const modalTemplateHtmlLabel = document.createElement("label");
+  modalTemplateHtmlLabel.className = "pdf-template-html-label";
+  const modalTemplateHtmlTextareaId = "pdfTemplateHtmlTextarea";
+  modalTemplateHtmlLabel.setAttribute("for", modalTemplateHtmlTextareaId);
+  modalTemplateHtmlLabel.textContent = "Éditeur HTML";
+
+  const modalTemplateHtmlTextarea = document.createElement("textarea");
+  modalTemplateHtmlTextarea.id = modalTemplateHtmlTextareaId;
+  modalTemplateHtmlTextarea.className = "pdf-template-html-textarea";
+  modalTemplateHtmlTextarea.setAttribute(
+    "aria-label",
+    "Modifier le HTML du template"
+  );
+  modalTemplateHtmlTextarea.spellcheck = false;
+
+  modalTemplateHtmlWrapper.appendChild(modalTemplateHtmlLabel);
+  modalTemplateHtmlWrapper.appendChild(modalTemplateHtmlTextarea);
+  modalTemplateSection.appendChild(modalTemplateHtmlWrapper);
+
   const modalTemplateHelper = document.createElement("p");
   modalTemplateHelper.className = "pdf-editor-helper";
   modalTemplateHelper.textContent =
@@ -150,6 +172,7 @@ function ensurePdfDatasetStructureModal() {
     fieldsContainer: modalFieldPalette,
     componentsContainer: modalComponentPalette,
     templateContainer: modalTemplateEditor,
+    templateHtmlTextarea: modalTemplateHtmlTextarea,
     previewContainer: modalPreview,
     open,
     close,
@@ -581,6 +604,7 @@ function editPdfDocumentComponent(type, element, content) {
   const fieldPalette = datasetStructureModal.fieldsContainer;
   const componentPalette = datasetStructureModal.componentsContainer;
   const templateEditor = datasetStructureModal.templateContainer;
+  const templateHtmlEditor = datasetStructureModal.templateHtmlTextarea;
   const livePreview = datasetStructureModal.previewContainer;
 
   const fileNameWrapper = document.createElement("div");
@@ -613,6 +637,14 @@ function editPdfDocumentComponent(type, element, content) {
 
   let currentFields = [];
   let currentRange = null;
+  let isSyncingFromHtmlEditor = false;
+
+  function updateTemplateHtmlTextarea(html) {
+    if (!templateHtmlEditor || isSyncingFromHtmlEditor) {
+      return;
+    }
+    templateHtmlEditor.value = html || "";
+  }
 
   function renderDatasetStructure(fields) {
     const hasFields = Array.isArray(fields) && fields.length > 0;
@@ -869,6 +901,7 @@ function editPdfDocumentComponent(type, element, content) {
         datasetStructurePreviewContainer.innerHTML = placeholder;
       }
     }
+    updateTemplateHtmlTextarea(html);
   }
 
   function getCleanTemplateHtml() {
@@ -1094,6 +1127,17 @@ function editPdfDocumentComponent(type, element, content) {
     const disconnectObserver = () => observer.disconnect();
     content.addEventListener("DOMNodeRemoved", disconnectObserver, { once: true });
     content.addEventListener("DOMNodeRemovedFromDocument", disconnectObserver, { once: true });
+  }
+
+  if (templateHtmlEditor) {
+    templateHtmlEditor.addEventListener("input", () => {
+      isSyncingFromHtmlEditor = true;
+      templateEditor.innerHTML = templateHtmlEditor.value;
+      prepareEditorTags();
+      updateLivePreview();
+      currentRange = null;
+      isSyncingFromHtmlEditor = false;
+    });
   }
 
   templateEditor.addEventListener("dragover", (event) => {


### PR DESCRIPTION
## Summary
- add an HTML textarea to the PDF template modal for quick source editing
- sync the textarea with the existing template editor and live preview updates
- style the HTML source editor to align with the modal layout

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e14f451c608321be20416b96f4a586