### PR TITLE
Centralize frontend fetch logic

### DIFF
--- a/public/js/apiClient.js
+++ b/public/js/apiClient.js
@@ -1,0 +1,31 @@
+(function () {
+  const isRequestInstance = (input) => {
+    return typeof Request !== 'undefined' && input instanceof Request;
+  };
+
+  const resolveUrl = (input) => {
+    if (typeof input === 'string') {
+      try {
+        return new URL(input, window.location.origin).toString();
+      } catch (error) {
+        console.error('apiFetch: unable to resolve URL', input, error);
+        throw error;
+      }
+    }
+
+    if (typeof URL !== 'undefined' && input instanceof URL) {
+      return input.toString();
+    }
+
+    throw new TypeError('apiFetch expects a string, URL, or Request instance as the first argument.');
+  };
+
+  window.apiFetch = function (input, options = {}) {
+    if (isRequestInstance(input)) {
+      return window.fetch(input, options);
+    }
+
+    const url = resolveUrl(input);
+    return window.fetch(url, options);
+  };
+})();

--- a/public/js/businessComponentSubmit.js
+++ b/public/js/businessComponentSubmit.js
@@ -44,7 +44,7 @@ function registerBusinessComponent(e) {
     };
 
     // Check if form exists
-    fetch(`/store-business-json/${objectId}`)
+    apiFetch(`/store-business-json/${objectId}`)
       .then((response) => {
         console.log("response");
         console.log(response);
@@ -58,7 +58,7 @@ function registerBusinessComponent(e) {
         console.log("existingForm");
         console.log(existingForm);
         // If form exists, update it
-        return fetch(`/update-business-component/${objectId}`, {
+        return apiFetch(`/update-business-component/${objectId}`, {
           method: "PUT",
           headers: {
             "Content-Type": "application/json",
@@ -70,7 +70,7 @@ function registerBusinessComponent(e) {
         console.log("error");
         console.log(error);
         // If form does not exist, store it
-        return fetch("/store-business-json", {
+        return apiFetch("/store-business-json", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/public/js/components/comboxComponent.js
+++ b/public/js/components/comboxComponent.js
@@ -124,7 +124,7 @@ function refreshCombox(element) {
     const DBName = jsonData[0].DBName;
     element.querySelector("label").innerText = fieldName;
     var url = "/select-distinct/" + DBName + "/" + tableName + "/" + fieldName;
-    fetch(url)
+    apiFetch(url)
         .then(response => response.json())
         .then(data => {
             var select = element.querySelector("select");

--- a/public/js/components/cookieStorage.js
+++ b/public/js/components/cookieStorage.js
@@ -162,7 +162,7 @@ function renderCookieStorage(main) {
                 select.style.width = "150px";
                 select.title = cookieValue;
                 const url = `/query-data/${DBName}/${SQL}`;
-                fetch(url)
+                apiFetch(url)
                     .then(response => response.json())
                     .then(data => {
                         data.forEach((val) => {

--- a/public/js/components/dataPanel.js
+++ b/public/js/components/dataPanel.js
@@ -188,7 +188,7 @@ function renderDataPanel(main) {
   // execute the sql
   // get the data with query select "/table-data-sql/:database/:page/:pageSize"?sqlQuery=select * from table
   const url = "/table-data-sql/" + dbName + "/1/10?sqlQuery=" + select;
-  const response = fetch(url, {
+  const response = apiFetch(url, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/public/js/components/dataSetComponent.js
+++ b/public/js/components/dataSetComponent.js
@@ -201,7 +201,7 @@ async function updateDataSet(main, content) {
     // get the db name
 
     // get the data with query select "/table-data-sql/:database/:page/:pageSize"?sqlQuery=select * from table
-    const response = await fetch(`/table-data-sql/${sqlJson.DBName}/1/1?sqlQuery=${sqlJson.select}`).then((response) => {
+    const response = await apiFetch(`/table-data-sql/${sqlJson.DBName}/1/1?sqlQuery=${sqlJson.select}`).then((response) => {
       if (!response.ok) {
         showToast("Error retrieving data", 5000);
       }
@@ -596,7 +596,7 @@ async function loadValuesSearchWin(event) {
   if (externalDBName == null || externalDBName == "" || query == null || query == "") {
     showToast("Please set external database name and SQL query for search window", 5000);
   }
-  fetch(`/table-data-sql/${externalDBName}/1/1000?sqlQuery=${query}`)
+  apiFetch(`/table-data-sql/${externalDBName}/1/1000?sqlQuery=${query}`)
     .then(response => response.json())
     .then(data => {
       // get the record of the fieldname = fieldvalue
@@ -693,7 +693,7 @@ async function linkRecordToGrid(DBName, tableName, rowId, rowNum, dataset, link,
       const url = `/get-record-by-rowid/${dataset[0].DBName}/${dataset[0].tableName}/${rowId}?fields=${datasetFields}`;
       //console.log("[FETCH by ROWID] URL:", url);
 
-      fetch(url)
+      apiFetch(url)
         .then((response) => response.json())
         .then((data) => {
           if (data.length > 0) {
@@ -746,7 +746,7 @@ async function linkRecordToGrid(DBName, tableName, rowId, rowNum, dataset, link,
 
 
       const url = `/get-records-by-indexes/${dataset[0].DBName}/${dataset[0].tableName}?indexes=${indexes}&values=${values}&fields=${datasetFields}`;
-      fetch(url)
+      apiFetch(url)
         .then((response) => response.json())
         .then((data) => {
           // get the divs document.querySelectorAll("#DataSet_" + tableName);
@@ -1066,7 +1066,7 @@ async function addFieldDescription(DBName, tableName) {
     const url = `/get-field-labels/${DBName}/${tableName}?fields=${datasetFields}`;
 
     // Fetch metadata (this should return array of { NAME, LABEL })
-    fetch(url)
+    apiFetch(url)
       .then((response) => response.json())
       .then((metadata) => {
         console.log("Field metadata received:", metadata);
@@ -1219,7 +1219,7 @@ function handleSelectFieldSQL(DBName, input, SQL, fieldLabel, selectedValue) {
 
   if (!selectElement) {
     const url = `/query-data/${DBName}/${encodeURIComponent(SQL)}`;
-    fetch(url)
+    apiFetch(url)
       .then((response) => response.json())
       .then((data) => {
         // convert the options to an array by fieldLabel

--- a/public/js/components/dataSetComponentNavigate.js
+++ b/public/js/components/dataSetComponentNavigate.js
@@ -1257,7 +1257,7 @@ async function CreateInsert(DBName, tableName, divLine) {
 async function navigateSequence(DBName, tableName, sequenceName) {
   const url = `/next-sequence/${DBName}/${tableName}/${sequenceName}`;
   try {
-    const response = await fetch(url);
+    const response = await apiFetch(url);
     const data = await response.json();
     return data[0]?.sequence_next; // Return the desired sequence
   } catch (error) {
@@ -1268,7 +1268,7 @@ async function navigateSequence(DBName, tableName, sequenceName) {
 
 async function updateRecordDB(DBName, tableName, nextRowId, data, actions) {
   try {
-    const response = await fetch(
+    const response = await apiFetch(
       `/update-record/${DBName}/${tableName}/${nextRowId}`,
       {
         method: "PUT",
@@ -1310,7 +1310,7 @@ async function updateRecordDB(DBName, tableName, nextRowId, data, actions) {
 
 async function insertRecordDB(DBName, tableName, data, actions, apikey) {
   try {
-    const response = await fetch(`/insert-record/${DBName}/${tableName}`, {
+    const response = await apiFetch(`/insert-record/${DBName}/${tableName}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -1341,7 +1341,7 @@ async function insertRecordDB(DBName, tableName, data, actions, apikey) {
 async function deleteRecordDB(DBName, tableName, rowId, actions) {
   console.log("New delete record from data set component navigate");
   try {
-    const response = await fetch(
+    const response = await apiFetch(
       `/delete-record/${DBName}/${tableName}/${rowId}`,
       {
         method: "POST",

--- a/public/js/components/databaseGrid.js
+++ b/public/js/components/databaseGrid.js
@@ -187,7 +187,7 @@ async function updateGridData(main, content) {
     // get the db name
 
     // get the data with query select "/table-data-sql/:database/:page/:pageSize"?sqlQuery=select * from table
-    const response = await fetch(`/table-data-sql/${sqlJson.DBName}/1/1?sqlQuery=${sqlJson.select}`).then((response) => {
+    const response = await apiFetch(`/table-data-sql/${sqlJson.DBName}/1/1?sqlQuery=${sqlJson.select}`).then((response) => {
       if (!response.ok) {
         showToast("Error retrieving data", 5000);
       }
@@ -806,7 +806,7 @@ async function submitGridImport(file, fieldNames, DBName, tableName, main, uploa
     formData.append("file", file);
     formData.append("fields", JSON.stringify(fieldNames));
 
-    const response = await fetch(`/import-table/${DBName}/${tableName}`, {
+    const response = await apiFetch(`/import-table/${DBName}/${tableName}`, {
       method: "POST",
       body: formData,
     });
@@ -979,7 +979,7 @@ async function gridGetData(
   }
   // Fetch the data from the web service
 
-  fetch(url).then(async response => {
+  apiFetch(url).then(async response => {
     // Parse the response as JSON
     console.log("Data fetched successfully");
 

--- a/public/js/components/databaseSearch.js
+++ b/public/js/components/databaseSearch.js
@@ -256,7 +256,7 @@ function searchAutoComplete(event, element) {
         url = url + " and " + fieldName + "='" + fieldValue + "'";
       });
     });
-    fetch(url)
+    apiFetch(url)
       .then((response) => response.json())
       .then((data) => {
         autocomplete.innerHTML = "";

--- a/public/js/components/databaseSearchH.js
+++ b/public/js/components/databaseSearchH.js
@@ -317,7 +317,7 @@ function searchAutoCompleteHorizontalH(event, input, acPanel) {
         });
     });
 
-    fetch(url)
+    apiFetch(url)
         .then((r) => r.json())
         .then((data) => {
             acPanel.innerHTML = "";

--- a/public/js/components/fileExplorerComponent.js
+++ b/public/js/components/fileExplorerComponent.js
@@ -76,7 +76,7 @@ function readFolder(path, fileExplorer, filter) {
     table.appendChild(tbody);
 
     const url = '/fileExplorer?directory=' + path;
-    fetch(url)
+    apiFetch(url)
         .then(response => {
             if (!response.ok) {
                 showToast('Error: ' + response.statusText);
@@ -177,7 +177,7 @@ function uploadFile(event, path, fileExplorer) {
         formData.append('fileupload', files[i], files[i].name);
 
     }
-    fetch(url, {
+    apiFetch(url, {
         method: 'POST',
         body: formData
     }).then(response => {

--- a/public/js/components/loginComponent.js
+++ b/public/js/components/loginComponent.js
@@ -141,7 +141,7 @@ function renderLoginComponent(element) {
                 const hashHex = hashArray.map(b => b.toString(16).padStart(2, "0")).join("");
                 formData.set("password", hashHex);
             }
-            await fetch(endpoint, { method: "POST", body: formData });
+            await apiFetch(endpoint, { method: "POST", body: formData });
         } catch (err) {
             console.error("Login failed", err);
         }

--- a/public/js/components/promptComponent.js
+++ b/public/js/components/promptComponent.js
@@ -885,8 +885,8 @@ async function fetchAIResponse(promptText) {
     // show the loader
     loader.style.display = 'block';
     // call ollama API or any AI service with the prompt text with full URL
-    // return  fetch('http://demo01:5001/api/v1/generate', {
-    return fetch('http://localhost:5001/api/v1/generate', {
+    // return  apiFetch('http://demo01:5001/api/v1/generate', {
+    return apiFetch('http://localhost:5001/api/v1/generate', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -1182,7 +1182,7 @@ async function askLmStudio(promptText) {
     const loader = document.getElementById('loader');
     // show the loader
     loader.style.display = 'block';
-    return fetch('/api/lm', {
+    return apiFetch('/api/lm', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prompt: promptText })
@@ -1218,7 +1218,7 @@ async function askAI(promptText) {
     const loader = document.getElementById('loader');
     // show the loader
     if (loader) loader.style.display = 'block';
-    const response = await fetch("/api/ask-ai", {
+    const response = await apiFetch("/api/ask-ai", {
         method: "POST",
         headers: {
             "Content-Type": "application/json"

--- a/public/js/components/searchWindow.js
+++ b/public/js/components/searchWindow.js
@@ -336,7 +336,7 @@ function updatePaginationControls(datasetJson) {
 async function fetchQueryData(DBName, query) {
   try {
     const url = `/query-data/${DBName}/${encodeURIComponent(query)}`;
-    const response = await fetch(url, { method: "GET" });
+    const response = await apiFetch(url, { method: "GET" });
     if (!response.ok) {
       throw new Error("Failed to fetch query data");
     }

--- a/public/js/components/translateComponent.js
+++ b/public/js/components/translateComponent.js
@@ -260,7 +260,7 @@ async function loadTranslationDictionary(forceReload = false) {
         return translationDictionaryPromise;
     }
 
-    translationDictionaryPromise = fetch('/api/translations', {
+    translationDictionaryPromise = apiFetch('/api/translations', {
         method: 'GET',
         headers: {
             'Content-Type': 'application/json',
@@ -285,7 +285,7 @@ async function loadTranslationDictionary(forceReload = false) {
 }
 
 async function saveTranslationDictionary(newDictionary) {
-    const response = await fetch('/api/translations', {
+    const response = await apiFetch('/api/translations', {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
@@ -304,7 +304,7 @@ async function saveTranslationDictionary(newDictionary) {
 }
 
 async function importTranslationDictionary(newDictionary) {
-    const response = await fetch('/api/translations/import', {
+    const response = await apiFetch('/api/translations/import', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -323,7 +323,7 @@ async function importTranslationDictionary(newDictionary) {
 }
 
 async function generateTranslationDictionaryWithAI(promptText, baseDictionary) {
-    const response = await fetch('/api/translations/ai-generate', {
+    const response = await apiFetch('/api/translations/ai-generate', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/public/js/db.js
+++ b/public/js/db.js
@@ -114,7 +114,7 @@ function createEditableTableList(list, tableDetails) {
 
 // called when you change the tab to create a new table
 function drageDroptableTableList(list) {
-    fetch('/tables-list')
+    apiFetch('/tables-list')
         .then(response => response.json())
         .then(dbs => {
             // Clear the list
@@ -185,7 +185,7 @@ function fetchTableFields(database, tableName, detailsDiv) {
     console.log('detailsDiv:', detailsDiv);
     removeAllChildNodes(detailsDiv);
 
-    fetch(`/table-fields/${database}/${tableName}`)
+    apiFetch(`/table-fields/${database}/${tableName}`)
         .then(response => response.json())
         .then(data => {
             console.log(data);
@@ -235,7 +235,7 @@ function fetchTableDetails(DBName, tableName, tableLabel, detailsDiv) {
     console.log('detailsDiv:', detailsDiv);
     removeAllChildNodes(detailsDiv);
     Promise.all([
-        fetch(`/table-fields/${DBName}/${tableName}`).then(response => response.json())
+        apiFetch(`/table-fields/${DBName}/${tableName}`).then(response => response.json())
     ])
         .then(([fields]) => {
 
@@ -415,7 +415,7 @@ function loadFieldsList(DBName, fieldName) {
     var select = document.querySelector('tr[data-field-name="' + fieldName + '"] select[name="fieldName"]');
     select.innerHTML = '';
     if (table) {
-        fetch(`/table-fields/${DBName}/${tableName}`)
+        apiFetch(`/table-fields/${DBName}/${tableName}`)
             .then(response => response.json())
             .then(fields => {
                 fields.forEach(field => {
@@ -435,7 +435,7 @@ async function editTableDetails(DBName, tableName, tableLabel, detailsDiv) {
     detailsDiv.innerHTML = '';
     try {
         // Fetch table fields
-        const response = await fetch(`/table-fields/${DBName}/${tableName}`);
+        const response = await apiFetch(`/table-fields/${DBName}/${tableName}`);
         const fields = await response.json();
         // Set innerHTML
         detailsDiv.innerHTML = `<h3 id='TableDetails_TableName' DBName='${DBName}' table-name='${tableName}'>Table Name:${tableName} Description:${tableLabel}</h3>`;
@@ -629,7 +629,7 @@ function addTableColumn(DBName, table) {
 
 async function alterTable(DBName, tableName, action, columnName, columnType, newColumnName, newColumnType) {
     try {
-        const response = await fetch(`/alter-table/${DBName}/${tableName}`, {
+        const response = await apiFetch(`/alter-table/${DBName}/${tableName}`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -751,7 +751,7 @@ async function createTable(DBName, table) {
 async function postCreateTable(DBName, tableName, columns) {
 
     try {
-        const response = await fetch(`/create-table/${DBName}/${tableName}`, {
+        const response = await apiFetch(`/create-table/${DBName}/${tableName}`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -856,7 +856,7 @@ function showModalDbStrc(main, type) {
             contentDiv.appendChild(table);
 
             header = ['X', 'NAME', 'LABEL', 'TYPE', 'MANDATORY', 'UP', 'DOWN'];
-            fetch(`/table-fields/${DBName}/${tableName}`).then(response => response.json())
+            apiFetch(`/table-fields/${DBName}/${tableName}`).then(response => response.json())
                 .then(fields => {
                     // add to the tbody the fields with this structure  const header = ['X', 'Field Name', 'Field Description', 'Type', 'Mandatory'];
                     //  console.log('fields:', fields);

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -879,7 +879,7 @@ function deleteElement() {
   parent.removeChild(editorElementSelected);
 
   // 🔁 Envoie la suppression au serveur
-  fetch('/api/delete-component', {
+  apiFetch('/api/delete-component', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
@@ -2153,7 +2153,7 @@ function createFilterField(main) {
       const url = `/select-distinct/${DBName}/${tableName}/${fieldName}`;
       //    const url = '/getDatasetDataDistinct/' + dataset + '/' + this.value;
 
-      fetch(url)
+      apiFetch(url)
         .then(response => response.json())
         .then(data => {
           multiSelect.innerHTML = '';
@@ -2292,7 +2292,7 @@ function generateJson(event) {
 
   // Here you could also send the JSON to a server, save it, or use it in some other way
   // For example:
-  // fetch('/api/filters', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(filterInfo) });
+  // apiFetch('/api/filters', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(filterInfo) });
 }
 
 // Function to regenerate filters from JSON

--- a/public/js/formSubmit.js
+++ b/public/js/formSubmit.js
@@ -44,7 +44,7 @@ function registerForm(e) {
     };
 
     // Check if form exists
-    fetch(`/get-form/${objectId}`)
+    apiFetch(`/get-form/${objectId}`)
       .then((response) => {
         console.log("response");
         console.log(response);
@@ -58,7 +58,7 @@ function registerForm(e) {
         console.log("existingForm");
         console.log(existingForm);
         // If form exists, update it
-        return fetch(`/update-form/${objectId}`, {
+        return apiFetch(`/update-form/${objectId}`, {
           method: "PUT",
           headers: {
             "Content-Type": "application/json",
@@ -70,7 +70,7 @@ function registerForm(e) {
         console.log("error");
         console.log(error);
         // If form does not exist, store it
-        return fetch("/store-json", {
+        return apiFetch("/store-json", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/public/js/listBusinessComponent.js
+++ b/public/js/listBusinessComponent.js
@@ -17,7 +17,7 @@
 async function loadBusinessComponent() {
   console.log("Loading Business component.......");
   try {
-    const response = await fetch("/list-business-component");
+    const response = await apiFetch("/list-business-component");
     if (!response.ok) {
       throw new Error("Network response was not ok");
     }
@@ -29,7 +29,7 @@ async function loadBusinessComponent() {
 }
 
 // function deleteForm(objectId, listItem) {
-//   fetch(`/delete-form/${objectId}`, { method: "DELETE" })
+//   apiFetch(`/delete-form/${objectId}`, { method: "DELETE" })
 //     .then((response) => {
 //       if (!response.ok) {
 //         throw new Error("Network response was not ok");
@@ -49,7 +49,7 @@ async function loadBusinessComponent() {
 //   objectId,
 //   renderContainer = document.getElementById("renderForm")
 // ) {
-//   fetch(`/get-form/${objectId}`)
+//   apiFetch(`/get-form/${objectId}`)
 //     .then((response) => {
 //       if (!response.ok) {
 //         throw new Error("Network response was not ok");

--- a/public/js/listForms.js
+++ b/public/js/listForms.js
@@ -21,7 +21,7 @@ let formsViewMode = 'grid';
 
 function loadForms() {
     console.log('Loading forms...');
-    fetch('/list-forms')
+    apiFetch('/list-forms')
         .then(response => {
             if (!response.ok) {
                 throw new Error('Network response was not ok');
@@ -268,7 +268,7 @@ function helperLoadContainer(event, objectId) {
 }
 
 function deleteForm(objectId) {
-    fetch(`/delete-form/${objectId}`, { method: 'DELETE' })
+    apiFetch(`/delete-form/${objectId}`, { method: 'DELETE' })
         .then(response => {
             if (!response.ok) {
                 throw new Error('Network response was not ok');
@@ -334,7 +334,7 @@ function updateAllIdsInJson(jsonObj, prefix) {
 
 function loadFormData(objectId, renderContainer, renderElem, prefix) {
     console.log("Load form data : " + objectId);
-    fetch(`/get-form/${objectId}`)
+    apiFetch(`/get-form/${objectId}`)
         .then(response => {
             if (!response.ok) {
                 throw new Error('Network response was not ok');
@@ -416,7 +416,7 @@ function loadFormDataInModal(objectId, container) {
     }
 
     // ❌ Sinon, faire le fetch
-    fetch(`/get-form/${objectId}`)
+    apiFetch(`/get-form/${objectId}`)
         .then(response => {
             if (!response.ok) throw new Error('Network error');
             return response.json();
@@ -681,7 +681,7 @@ async function newForm() {
     };
 
     try {
-        const response = await fetch("/create-form", {
+        const response = await apiFetch("/create-form", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(formPayload),

--- a/public/js/listPages.js
+++ b/public/js/listPages.js
@@ -18,7 +18,7 @@ let pagesViewMode = 'grid';
 
 function loadPages() {
 
-    fetch("/pages").then(response => {
+    apiFetch("/pages").then(response => {
         if (!response.ok) {
             throw new Error("Network response was not ok");
         }
@@ -253,7 +253,7 @@ function togglePagesView(mode) {
 
 function loadPage(pageId) {
     console.log("Loading page with ID:", pageId);
-    fetch(`/pages/${pageId}`)
+    apiFetch(`/pages/${pageId}`)
         .then(response => {
             if (!response.ok) {
                 showToast("Error loading page: " + response.statusText);
@@ -355,7 +355,7 @@ function registerPage(e) {
             header: header,
         };
         // post the form data to the server to store it /page
-        fetch("/pages", {
+        apiFetch("/pages", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json"
@@ -377,7 +377,7 @@ function registerPage(e) {
 
 function deletePage(pageID) {
     if (confirm("Are you sure you want to delete this page?")) {
-        fetch(`/pages/${pageID}`, {
+        apiFetch(`/pages/${pageID}`, {
             method: "DELETE"
         })
             .then(response => {

--- a/public/js/loadComponents.js
+++ b/public/js/loadComponents.js
@@ -68,7 +68,7 @@ function loadCssIfNotLoaded(cssUrl, csslist) {
   // Check if the css is already loaded
   if (csslist.indexOf(cssUrl) === -1) {
     // The css is not loaded, check if it exists and load it
-    fetch(cssUrl)
+    apiFetch(cssUrl)
       .then((response) => {
         if (response.ok) {
           // The css exists, load it
@@ -93,7 +93,7 @@ function loadScriptIfNotLoaded(scriptUrl, scriptslist) {
   // Check if the script is already loaded
 
   // The script is not loaded, check if it exists and load it
-  return fetch(scriptUrl)
+  return apiFetch(scriptUrl)
     .then((response) => {
       if (response.ok) {
         // The script exists, load it
@@ -430,7 +430,7 @@ function doubleclick(event) {
 
 // Assuming you're in a browser environment
 async function loadJson(url) {
-  const response = await fetch(url);
+  const response = await apiFetch(url);
   const data = await response.json();
   return data;
 }

--- a/public/js/loadFormWithApiKey.js
+++ b/public/js/loadFormWithApiKey.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded", () => {
         return;
     }
 
-    fetch(url, {
+    apiFetch(url, {
         method: "GET",
         headers: {
             "Content-Type": "application/json",

--- a/public/js/msjv2/authPopup.js
+++ b/public/js/msjv2/authPopup.js
@@ -123,7 +123,7 @@ function showWelcomeMessage(username) {
     // and print the response in innerHTML
     getTokenRedirect(loginRequest)
         .then(response => {
-            fetch('/customLogin', {
+            apiFetch('/customLogin', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/public/js/msjv2/authRedirect.js
+++ b/public/js/msjv2/authRedirect.js
@@ -69,7 +69,7 @@ function signOut() {
     // 🔐 Déconnexion Azure
     myMSALObj.logoutPopup(logoutRequest).then(() => {
         // 🔐 Déconnexion backend (Express)
-        fetch('/logout', { credentials: 'include' })
+        apiFetch('/logout', { credentials: 'include' })
             .then(() => {
                 window.location.href = '../../../../views/login.ejs'; // ← chemin vers ton vrai login
             })

--- a/public/js/msjv2/graph.js
+++ b/public/js/msjv2/graph.js
@@ -15,7 +15,7 @@ function callMSGraph(endpoint, token, callback) {
 
     console.log('request made to Graph API at: ' + new Date().toString());
 
-    fetch(endpoint, options)
+    apiFetch(endpoint, options)
         .then(response => response.json())
         .then(response => callback(response, endpoint))
         .catch(error => console.log(error));

--- a/public/js/webserver.js
+++ b/public/js/webserver.js
@@ -316,7 +316,7 @@ async function fetchAndParseOpenApiJson(url) {
     if (!url) {
       return null;
     }
-    const response = await fetch(url);
+    const response = await apiFetch(url);
 
     if (!response.ok) {
       throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
@@ -928,13 +928,13 @@ async function callApi(apiUrl, apiMethod, body = {}) {
     let response;
     switch (apiMethod) {
       case "GET":
-        response = await fetch(apiUrl, {
+        response = await apiFetch(apiUrl, {
           method: "GET",
         });
         break;
 
       case "POST":
-        response = await fetch(apiUrl, {
+        response = await apiFetch(apiUrl, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -944,7 +944,7 @@ async function callApi(apiUrl, apiMethod, body = {}) {
         break;
 
       case "PUT":
-        response = await fetch(apiUrl, {
+        response = await apiFetch(apiUrl, {
           method: "PUT",
           headers: {
             "Content-Type": "application/json",
@@ -954,7 +954,7 @@ async function callApi(apiUrl, apiMethod, body = {}) {
         break;
 
       case "PATCH":
-        response = await fetch(apiUrl, {
+        response = await apiFetch(apiUrl, {
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",
@@ -964,7 +964,7 @@ async function callApi(apiUrl, apiMethod, body = {}) {
         break;
 
       case "Delete":
-        response = await fetch(apiUrl, {
+        response = await apiFetch(apiUrl, {
           method: "DELETE",
         });
         break;

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -48,9 +48,10 @@
     </tbody>
   </table>
 
+  <script src="/js/apiClient.js"></script>
   <script>
     async function fetchPages() {
-      const res = await fetch("/api/pages");
+      const res = await apiFetch("/api/pages");
       const pages = await res.json();
       const tbody = document.querySelector("#pages-table tbody");
       tbody.innerHTML = "";
@@ -78,7 +79,7 @@
 
     async function deletePage(id) {
       if (!confirm("Confirmer la suppression ?")) return;
-      const res = await fetch(`/api/pages/${id}`, { method: "DELETE" });
+      const res = await apiFetch(`/api/pages/${id}`, { method: "DELETE" });
       if (res.ok) {
         alert("Page supprimée");
         fetchPages();

--- a/views/editor.ejs
+++ b/views/editor.ejs
@@ -68,6 +68,7 @@
   </aside>
 
   <script src="https://unpkg.com/grapesjs"></script>
+  <script src="/js/apiClient.js"></script>
   <script>
     // definition de l'éditeur GrapesJS with html, css, and js components
     const editor = grapesjs.init({
@@ -143,7 +144,7 @@
     // Charger une page existante depuis l’API
     const pageId = new URLSearchParams(window.location.search).get("id");
     if (pageId) {
-      fetch(`/api/pages/${pageId}`)
+      apiFetch(`/api/pages/${pageId}`)
         .then(res => res.json())
         .then(page => {
           editor.setComponents(page.content);
@@ -174,7 +175,7 @@
           meta: {}
         };
 
-        fetch(pageId ? `/api/pages/${pageId}` : `/api/pages`, {
+        apiFetch(pageId ? `/api/pages/${pageId}` : `/api/pages`, {
           method: pageId ? 'PUT' : 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)

--- a/views/media-library.ejs
+++ b/views/media-library.ejs
@@ -81,11 +81,12 @@
     </div>
   </div>
   <!-- Script to fetch and render images -->
+  <script src="/js/apiClient.js"></script>
   <script>
     // Function to fetch images from the /images endpoint
     async function fetchMedia() {
       try {
-        const response = await fetch('/media');
+        const response = await apiFetch('/media');
         if (!response.ok) {
           throw new Error('Failed to fetch images');
         }
@@ -167,7 +168,7 @@
       const uploadForm = document.getElementById('uploadForm');
       const formData = new FormData(uploadForm);
       try {
-        const response = await fetch('/upload-media', {
+        const response = await apiFetch('/upload-media', {
           method: 'POST',
           body: formData,
         });

--- a/views/partials/scripts.ejs
+++ b/views/partials/scripts.ejs
@@ -16,6 +16,7 @@
 <script src="https://unpkg.com/html5-qrcode"></script>
 
 <!-- Tes scripts applicatifs -->
+<script src="js/apiClient.js"></script>
 <script src="js/db.js"></script>
 <script src="js/loadComponents.js"></script>
 <script src="js/Components/userComponent.js"></script>


### PR DESCRIPTION
## Summary
- add a shared `apiFetch` helper that resolves absolute URLs before delegating to `window.fetch`
- load the helper in relevant EJS templates so it is available to all frontend scripts
- refactor frontend components to call `apiFetch` instead of using `fetch` directly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e20752ffd48321b86c46d9e885fd78