### PR TITLE
Improve edit form layout and add page header support

### DIFF
--- a/public/css/editForm.css
+++ b/public/css/editForm.css
@@ -9,34 +9,45 @@
 }
 
 .editor-fields {
-    gap: 12px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+    align-items: start;
 }
 
 .editor-fields .form-field {
     display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: nowrap;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .editor-fields .form-field label {
     margin-bottom: 0;
-    white-space: nowrap;
+    font-weight: 600;
+}
+
+.editor-fields .form-field small {
+    color: var(--color-36);
+    font-size: 0.85rem;
 }
 
 .editor-fields .form-field input,
 .editor-fields .form-field select,
 .editor-fields .form-field textarea {
-    flex: 1 1 auto;
-    min-width: 0;
+    width: 100%;
 }
 
-.editor-fields .form-field--textarea {
-    align-items: flex-start;
+.editor-fields .form-field--textarea textarea {
+    resize: vertical;
 }
 
-.editor-fields .form-field--textarea label {
-    padding-top: 0.25rem;
+.editor-fields .form-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 0;
+    grid-column: 1 / -1;
+    flex-wrap: wrap;
 }
 
 

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -204,9 +204,10 @@ function editElement(element) {
     }
   }
   // check if in the formDataForm the value of objectType = page
-  const formDataForm = document.getElementById("formDataForm");
-  if (formDataForm && formDataForm.objectType && formDataForm.objectType.value === "page") {
-    // create a box to show and edit the header of the page and store the it in hidden input pageHeader
+  const typeSelect = document.getElementById("objectType");
+  const headerTextarea = document.getElementById("pageHeaderTextarea");
+  if (typeSelect && typeSelect.value === "page") {
+    // create a box to show and edit the header of the page and store it in the header textarea
     const headerBox = document.createElement("div");
     headerBox.className = "editor-box";
     headerBox.style.border = "1px solid #ccc";
@@ -218,19 +219,21 @@ function editElement(element) {
     // create an input to edit the header
     const headerInput = document.createElement("textarea");
     headerInput.type = "textarea";
-    // set the textarea to be 100% width
     headerInput.style.width = "100%";
-    // set the textarea to 3 rows
     headerInput.rows = 3;
-    headerInput.id = "pageHeader";
-    headerInput.value = formDataForm.pageHeader ? formDataForm.pageHeader.value : "";
+    headerInput.id = "pageHeaderEditor";
+    headerInput.value = headerTextarea ? headerTextarea.value : "";
     headerInput.style.fontSize = "9px";
     headerInput.style.marginBottom = "5px";
     headerInput.onchange = () => {
       const newHeader = headerInput.value.trim();
+      if (headerTextarea) {
+        headerTextarea.value = newHeader;
+      }
       if (newHeader) {
-        formDataForm.pageHeader.value = newHeader; // Update the form's hidden input
         element.setAttribute("data-page-header", newHeader); // Set the attribute on the element
+      } else {
+        element.removeAttribute("data-page-header");
       }
     };
     // Append the input to the headerBox

--- a/public/js/listPages.js
+++ b/public/js/listPages.js
@@ -268,10 +268,15 @@ function loadPage(pageId) {
             document.getElementById("objectSlug").value = page.slug;
             document.getElementById("userCreated").value = page.userCreated;
             document.getElementById("userModified").value = page.userModified;
-            document.getElementById("objectTypeHidden").value = page.header || ""; // Use header if available
             var objectType = document.getElementById('objectType');
             // select in the objecttype the value form
             objectType.value = 'page';
+            const headerTextarea = document.getElementById("pageHeaderTextarea");
+            if (headerTextarea) {
+                headerTextarea.value = page.header || "";
+            }
+            const changeEvent = new Event('change');
+            objectType.dispatchEvent(changeEvent);
             // Assuming formContainer is where the page content is displayed
             const formContainer = document.getElementById("formContainer");
             formContainer.innerHTML = ""; // Clear existing content
@@ -326,7 +331,8 @@ function registerPage(e) {
     var userCreated = document.getElementById("userCreated").value;
     var userModified = document.getElementById("userModified").value;
     var type = document.getElementById("objectType").value;
-    var header = document.getElementById("objectTypeHidden").value;
+    var headerField = document.getElementById("pageHeaderTextarea");
+    var header = headerField ? headerField.value : "";
 
     var formContainer = document.getElementById("formContainer");
     // var jsonData = domToJson(formContainer);

--- a/views/tabs/editForm.ejs
+++ b/views/tabs/editForm.ejs
@@ -2,8 +2,7 @@
     <div class="row display-flex" id="formProperties" style="width: 100%; padding: 10px;">
         <!-- Form properties will be added here -->
         <form class="container-fluid" id="formDataForm">
-            <div class="row table-hover editor-fields"
-                style="display:flex;align-items:flex-start;justify-content:center;flex-wrap:wrap;">
+            <div class="row table-hover editor-fields">
                 <div class="col form-field">
                     <label for="objectId" class="input-group-text">ID:</label>
                     <input class="input-element" id="objectId" name="objectId" placeholder="ID" required type="text"
@@ -31,38 +30,42 @@
                 </div>
                 <div class="col form-field">
                     <label for="objectType">Type:</label>
-                    <select class="input-element" id="objectType" name="type" required>
+                    <select class="input-element" id="objectType" name="objectType" required>
                         <option value="" disabled selected>Select Type</option>
                         <option value="page">Page</option>
                         <option value="form">Form</option>
                         <option value="business_component">Business Component</option>
                     </select>
-                    <input id="objectTypeHidden" name="pageHeader" type="hidden" value="">
+                </div>
+                <div class="col form-field form-field--textarea" id="pageHeaderGroup" hidden>
+                    <label for="pageHeaderTextarea">Header:</label>
+                    <textarea class="input-element" id="pageHeaderTextarea" name="pageHeader"
+                        placeholder="Insert header HTML" rows="4"></textarea>
+                    <small class="form-text">Displayed when the selected type is "Page".</small>
                 </div>
                 <div class="col form-field form-field--textarea">
                     <label for="objectDescription">Description:</label>
                     <textarea class="input-element" id="objectDescription" name="objectDescription"
                         placeholder="Insert Description" required rows="3"></textarea>
                 </div>
-                <div class="col" style="display:inline-block;padding:10px">
+                <div class="col form-actions">
                     <button class="button form-edit-button success" id="registerObjectBtn"
-                        onclick="registerObject(event)" title="Register Object" type="button" style="float:left;">
+                        onclick="registerObject(event)" title="Register Object" type="button">
                         <i class="bi bi-check-lg"></i>
                     </button>
                     <button class="button form-edit-button" id="clearObjectBtn" onclick="showClearConfirmation()"
-                        title="Clear" type="button" style="float:left;">
+                        title="Clear" type="button">
                         <i class="bi bi-trash"></i>
                     </button>
                     <button class="button form-edit-button" id="undoDeleteBtn" onclick="undoDelete()"
-                        title="Undo Delete" type="button" style="float:left;">
+                        title="Undo Delete" type="button">
                         <i class="bi bi-arrow-counterclockwise"></i>
                     </button>
                     <button class="button form-edit-button" onclick="exportJson()" title="Export JSON" type="button"
-                        style="float:left;">
                         <i class="bi bi-filetype-json"></i>
                     </button>
                     <button class="button form-edit-button" id="createFormBtn" onclick="promptCreateForm()"
-                        title="Create Form" type="button" style="float: left;">
+                        title="Create Form" type="button">
                         <i class="bi bi-ui-checks"></i>
                     </button>
                 </div>
@@ -171,6 +174,24 @@
 
 <script>
     const root = document.getElementById('editForm');
+    const typeSelect = document.getElementById('objectType');
+    const pageHeaderGroup = document.getElementById('pageHeaderGroup');
+    const pageHeaderTextarea = document.getElementById('pageHeaderTextarea');
+
+    function togglePageHeaderField(selectedType) {
+        if (!pageHeaderGroup) {
+            return;
+        }
+        const isPage = selectedType === 'page';
+        pageHeaderGroup.hidden = !isPage;
+    }
+
+    if (typeSelect) {
+        togglePageHeaderField(typeSelect.value);
+        typeSelect.addEventListener('change', (event) => {
+            togglePageHeaderField(event.target.value);
+        });
+    }
 
     // Panneaux
     const sideComponents = document.getElementById('componentsSidebar');


### PR DESCRIPTION
## Summary
- restyle the edit form header fields with a grid layout for consistent alignment
- add a dedicated textarea for page headers that appears when the page type is selected
- synchronize page header editing with the editor sidebar and include the value when saving pages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e78b66fde08321ad4aeccf85d03194