### PR TITLE
Center prompt component layout

### DIFF
--- a/public/css/components/promptComponent.css
+++ b/public/css/components/promptComponent.css
@@ -1,4 +1,12 @@
 @import "../variables.css";
+
+.prompt-component-wrapper {
+  width: 80%;
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+}
+
 #chat-container {
   background: var(--color-147);
   padding: 15px;

--- a/public/js/components/promptComponent.js
+++ b/public/js/components/promptComponent.js
@@ -27,7 +27,7 @@
  */
 function createPromptComponent(type) {
     var main = document.createElement('div');
-    main.className = 'form-container';
+    main.className = 'form-container prompt-component-wrapper';
     main.id = type + Date.now(); // Unique ID for each new element
     main.draggable = true;
     main.tagName = type;
@@ -75,6 +75,9 @@ function editPromptComponent(type, element, content) {
  *        des boutons d'action et du loader associé au composant.
  */
 function renderPromptComponent(element) {
+    if (element.classList && !element.classList.contains('prompt-component-wrapper')) {
+        element.classList.add('prompt-component-wrapper');
+    }
     element.innerHTML = `<div id="chat-container">
                     <textarea id="PromptText" placeholder="Type your message..."></textarea>
 


### PR DESCRIPTION
## Summary
- add a dedicated wrapper class around the prompt component so it can be centered
- style the wrapper to use 80% of the parent width and center the prompt contents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7bbc9e16083218a2a4ea896580291